### PR TITLE
Prevent acceptance context from clearing extra_env

### DIFF
--- a/lib/vagrant-spec/acceptance/rspec/context.rb
+++ b/lib/vagrant-spec/acceptance/rspec/context.rb
@@ -12,8 +12,6 @@ shared_context "acceptance" do
 
   let(:config) { Vagrant::Spec::Acceptance.config }
 
-  let(:extra_env) { {} }
-
   # The skeleton paths that will be used to configure environments.
   let(:skeleton_paths) do
     root = Vagrant::Spec.source_root.join("acceptance", "support-skeletons")
@@ -30,7 +28,7 @@ shared_context "acceptance" do
   def new_environment(env=nil)
     apps = { "vagrant" => config.vagrant_path }
     env  = config.env.merge(env || {})
-    env.merge!(extra_env)
+    env.merge!(extra_env) if defined? extra_env
 
     Vagrant::Spec::AcceptanceIsolatedEnvironment.new(
       apps: apps,


### PR DESCRIPTION
Provider-specific contexts are usually included before the acceptance context.
This meant that when acceptance defined `extra_env` to be an empty hash, any
environment variables set by the provider context were lost.

This patch removes the empty hash definition from acceptance and instead guards
the use of `extra_env` with `defined?`.
