### PR TITLE
Speed up nokogiri installation during Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
 rvm:
     - 2.0.0
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 script: bundle exec rspec


### PR DESCRIPTION
Version 1.6 of Nokogiri builds its own copy of libxml2 during installation.
Setting `NOKOGIRI_USE_SYSTEM_LIBRARIES=true` skips this step and shaves a
couple minutes off of Travis runs.
