### PR TITLE
Fixing deprecation warnings on failure_message

### DIFF
--- a/lib/vagrant-spec/acceptance/rspec/matcher_exit_with.rb
+++ b/lib/vagrant-spec/acceptance/rspec/matcher_exit_with.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :exit_with do |code|
     actual.exit_code == code
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected command to exit with #{code} but got exit code: #{actual.exit_code}\n\n" +
       "stdout: #{actual.stdout}\n\n" +
       "stderr: #{actual.stderr}"

--- a/lib/vagrant-spec/acceptance/rspec/matcher_match_output.rb
+++ b/lib/vagrant-spec/acceptance/rspec/matcher_match_output.rb
@@ -8,7 +8,7 @@ RSpec::Matchers.define :match_output do |expected, *args|
     Vagrant::Spec::OutputTester.matches?(actual, expected, *args)
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected output to match: #{expected} #{args.inspect}\n\n" +
       "output: #{actual}"
   end


### PR DESCRIPTION
Fixing deprecations warning message:
```
`failure_message_for_should` is deprecated. Use `failure_message` instead
```

This seems to have appeared in Rspec >3.4
Since `vagrant-spec` is dependant on Rspec >3.5 this should be ok to
replace.