### PR TITLE
Update box outdated test

### DIFF
--- a/acceptance/cli/box_spec.rb
+++ b/acceptance/cli/box_spec.rb
@@ -192,7 +192,7 @@ describe "vagrant CLI: box", component: "cli/box" do
 
       result = execute("vagrant", "box", "outdated", "--global")
       expect(result).to exit_with(0)
-      expect(result.stdout).to match_output(:box_outdated, "foo/bar", "0.7", "0.9")
+      expect(result.stdout).to match_output(:box_outdated, "foo/bar", "empty_provider", "0.7", "0.9")
     end
   end
 end

--- a/acceptance/output/box_output.rb
+++ b/acceptance/output/box_output.rb
@@ -28,8 +28,8 @@ module Vagrant
     end
 
     # Tests that box is outdated
-    OutputTester[:box_outdated] = lambda do |text, name, old, new|
-      text =~ /'#{name}' is outdated! Current: #{old}\. Latest: #{new}/
+    OutputTester[:box_outdated] = lambda do |text, name, provider, old_v, new_v|
+      text =~ /'#{name}' for '#{provider}' is outdated! Current: #{old_v}\. Latest: #{new_v}/
     end
 
     # Tests that box is up to date


### PR DESCRIPTION
Because the box outdated command updated it's output, this commit
updates the test to properly look for and match against the updated
output.