### PR TITLE
Configure logging behaviour of execute and assert_execute

### DIFF
--- a/lib/vagrant-spec/acceptance/configuration.rb
+++ b/lib/vagrant-spec/acceptance/configuration.rb
@@ -37,6 +37,9 @@ module Vagrant
         # different depending on mode.
         attr_accessor :run_mode
 
+        # Whether to log the command executed by `execute` or `assert_execute`.
+        attr_accessor :log_execute
+
         def initialize
           @component_paths = [
             Vagrant::Spec.source_root.join("acceptance"),
@@ -48,6 +51,7 @@ module Vagrant
           @skeleton_paths = []
           @vagrant_path   = "vagrant"
           @run_mode       = "standalone"
+          @log_execute    = true
         end
 
         # Tells vagrant-spec to acceptance test a certain provider.

--- a/lib/vagrant-spec/acceptance/rspec/context.rb
+++ b/lib/vagrant-spec/acceptance/rspec/context.rb
@@ -45,7 +45,7 @@ shared_context "acceptance" do
   # Executes the given command in the context of the isolated environment.
   #
   # @return [Object]
-  def execute(*args, env: nil, log: true, &block)
+  def execute(*args, env: nil, log: config.log_execute, &block)
     env ||= environment
     status("Execute: #{args.join(" ")}") if log
     env.execute(*args, &block)


### PR DESCRIPTION
Adds a Acceptance::Configuration attribute `log_execute` to globally configure the default logging behaviour. Default is `true` to keep the old default.

(I could use some help to create a spec for this though)