### PR TITLE
Test synced folder persists after guest reboot

### DIFF
--- a/acceptance/provider/synced_folder_spec.rb
+++ b/acceptance/provider/synced_folder_spec.rb
@@ -29,5 +29,12 @@ shared_examples "provider/synced_folder" do |provider, options|
     status("Test: doesn't mount a disabled folder")
     result = execute("vagrant", "ssh", "-c", "test -d /foo")
     expect(result.exit_code).to eql(1)
+
+    status("Test: persists a sync folder after a manual reboot")
+    result = execute("vagrant", "ssh", "-c", "sudo reboot")
+    expect(result).to exit_with(255)
+    result = execute("vagrant", "ssh", "-c", "cat /vagrant/foo")
+    expect(result.exit_code).to eql(0)
+    expect(result.stdout).to match(/hello$/)
   end
 end

--- a/acceptance/provider/synced_folder_spec.rb
+++ b/acceptance/provider/synced_folder_spec.rb
@@ -36,5 +36,9 @@ shared_examples "provider/synced_folder" do |provider, options|
     result = execute("vagrant", "ssh", "-c", "cat /vagrant/foo")
     expect(result.exit_code).to eql(0)
     expect(result.stdout).to match(/hello$/)
+
+    status("Test: guest has permissions to write to synced folder")
+    result = execute("vagrant", "ssh", "-c", "echo goodbye > /vagrant/bar")
+    expect(result.exit_code).to eql(0)
   end
 end

--- a/acceptance/support-skeletons/synced_folders/Vagrantfile
+++ b/acceptance/support-skeletons/synced_folders/Vagrantfile
@@ -3,4 +3,7 @@ Vagrant.configure("2") do |config|
 
   # Test that disabled works
   config.vm.synced_folder "../", "/foo", disabled: true
+
+  # Test that synced folders persist after provisioner reboot
+  config.vm.provision "reboot", type: :shell, inline: "reboot", run: "never"
 end


### PR DESCRIPTION
This test checks to see that a VirtualBox synced folder persists outside
of a `vagrant reload`, such as when a machine is manually rebooted or
restarted by the provider directly.

https://github.com/hashicorp/vagrant/pull/11570