### PR TITLE
Skip SMB tests for linux hosts

### DIFF
--- a/acceptance/synced_folder/smb_spec.rb
+++ b/acceptance/synced_folder/smb_spec.rb
@@ -16,7 +16,8 @@ shared_examples "provider/synced_folder/smb" do |provider, options|
     assert_execute("vagrant", "destroy", "--force")
   end
 
-  it "properly configures SMB", :skip_windows_guest do
+  # SMB is not supported for linux hosts
+  it "properly configures SMB", :skip_linux_hosts do
     status("Test: does initial smb sync")
     result = execute("vagrant", "ssh", "-c", "cat /vagrant-smb/foo")
     expect(result).to exit_with(0)

--- a/lib/vagrant-spec/acceptance/rspec.rb
+++ b/lib/vagrant-spec/acceptance/rspec.rb
@@ -10,4 +10,8 @@ RSpec.configure do |c|
   if ENV["VAGRANT_SPEC_GUEST_PLATFORM"].to_s == "windows"
     c.filter_run_excluding :skip_windows_guest
   end
+
+  if RUBY_PLATFORM.match(/linux/)
+    c.filter_run_excluding :skip_linux_hosts
+  end
 end


### PR DESCRIPTION
SMB is not supported for linux hosts

ref: https://www.vagrantup.com/docs/synced-folders/smb
"SMB is currently only supported when the host machine is Windows or macOS. The guest machine can be Windows, Linux, or macOS."