### PR TITLE
Add sleeps to the test case for synced folders after manual VM reboot

### DIFF
--- a/acceptance/provider/synced_folder_spec.rb
+++ b/acceptance/provider/synced_folder_spec.rb
@@ -35,8 +35,13 @@ shared_examples "provider/synced_folder" do |provider, options|
     expect(result.exit_code).to eql(0)
 
     status("Test: persists a sync folder after a manual reboot")
-    result = execute("vagrant", "ssh", "-c", "sudo reboot")
+    # Need to add a sleep here to make sure that the command will be executed for
+    # long enough to be killed by the reboot and exit with code 255, confirming the reboot
+    result = execute("vagrant", "ssh", "-c", "sudo reboot && sleep 30")
     expect(result).to exit_with(255)
+    # Need to do a manual sleep here because Vagrant doesn't know that the
+    # machine is rebooting
+    sleep 10
     result = execute("vagrant", "ssh", "-c", "cat /vagrant/foo")
     expect(result.exit_code).to eql(0)
     expect(result.stdout).to match(/hello$/)


### PR DESCRIPTION
First `sleep` is needed to make sure that `vagrant ssh` command will be long enough to be killed by reboot. Otherwise, it can exit fast with code 0, failing the assert.

The second `sleep` is needed to make sure that the subsequent command (`cat`) will be executed late enough, when the reboot is in progress. Otherwise, we can reach the guest before the actual reboot, which is not a valid verification.
That's, basically, the same reason why sleep has been added earlier to the "provisioner reboot" case defined below (line 54).
