### PR TITLE
Use nonzero exit code on failure

### DIFF
--- a/lib/vagrant-spec/cli.rb
+++ b/lib/vagrant-spec/cli.rb
@@ -28,8 +28,13 @@ module Vagrant
       def test
         load_config
 
-        Acceptance::Runner.new(paths: Acceptance.config.component_paths).
-          run(options[:components], example: options[:example], without_components: options[:without_components])
+        status = Acceptance::Runner.new(paths: Acceptance.config.component_paths)
+                                   .run(
+                                     options[:components],
+                                     example: options[:example],
+                                     without_components: options[:without_components]
+                                   )
+        exit(status) if status != 0
       end
 
       protected


### PR DESCRIPTION
`Acceptance::Runner` delegates to `Rspec::Core::Runner.run` which
returns an exit code. We just need to mirror the behavior of
`Rspec::Core::Runner.invoke` and exit using the status code.

See https://rspec.info/documentation/3.10/rspec-core/RSpec/Core/Runner.html#run-class_method