### PR TITLE
Loosen version output requirements

### DIFF
--- a/acceptance/output/version_output.rb
+++ b/acceptance/output/version_output.rb
@@ -4,7 +4,7 @@ module Vagrant
   module Spec
     # Tests the Vagrant version output
     OutputTester[:version] = lambda do |text|
-      text =~ /^Vagrant (\d+\.\d+\.\d+(\.[a-z0-9]+)?)$/
+      text =~ /^Vagrant (\d+\.\d+\.\d+(\.[a-z0-9]+)?).*$/
     end
   end
 end

--- a/lib/vagrant-spec/acceptance/rspec/formatter.rb
+++ b/lib/vagrant-spec/acceptance/rspec/formatter.rb
@@ -1,4 +1,5 @@
 require "rspec/core/formatters/documentation_formatter"
+require "rspec/legacy_formatters"
 
 module Vagrant
   module Spec

--- a/vagrant-spec.gemspec
+++ b/vagrant-spec.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'vagrant-spec/version'
@@ -21,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "childprocess"
   spec.add_dependency "log4r", "~> 1.1.9"
   spec.add_dependency "rspec", "~> 3.10"
+  spec.add_dependency "rspec-legacy_formatters", "~> 1.0"
   spec.add_dependency "thor", "~> 0.18.1"
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
```
commit bb7090598ce4010fe332d66154fcd7c3a0e35ff6
Author: Paul Hinze <phinze@phinze.com>
Date:   Thu Feb 24 15:58:42 2022 -0600

    Loosen version matcher to support additional stuff on the end

    This will safely match some of the additional details that show up on
    the end of the build as we work on the road to Vagrant 3.0

commit 38782687064ee327ded6cc6be69b2c0aa1b2a369
Author: Paul Hinze <phinze@phinze.com>
Date:   Thu Feb 24 15:57:55 2022 -0600

    Fix formatter issues and deprecation warnings in RSpec 3
```