### PR TITLE
Provide a config option to debug failures

### DIFF
--- a/lib/vagrant-spec/acceptance/configuration.rb
+++ b/lib/vagrant-spec/acceptance/configuration.rb
@@ -37,6 +37,12 @@ module Vagrant
         # different depending on mode.
         attr_accessor :run_mode
 
+        # Remove isolated environment on example failure. By default this
+        # is set to be true, but can be disabled by setting to false which
+        # will result in teardown skipping removal and messaging the output
+        # as to the paths retained.
+        attr_accessor :clean_on_fail
+
         def initialize
           @component_paths = [
             Vagrant::Spec.source_root.join("acceptance"),
@@ -48,6 +54,7 @@ module Vagrant
           @skeleton_paths = []
           @vagrant_path   = "vagrant"
           @run_mode       = "standalone"
+          @clean_on_fail  = true
         end
 
         # Tells vagrant-spec to acceptance test a certain provider.

--- a/lib/vagrant-spec/acceptance/rspec/context.rb
+++ b/lib/vagrant-spec/acceptance/rspec/context.rb
@@ -23,8 +23,12 @@ shared_context "acceptance" do
     config.skeleton_paths.dup.unshift(root)
   end
 
-  after(:each) do
-    environment.close
+  after(:each) do |example|
+    if example.exception.nil? || config.clean_on_fail
+      environment.close
+    else
+      example.reporter.message("Temporary work and home dirs (#{environment.workdir} and #{environment.homedir}) not removed to allow debug")
+    end
   end
 
   # Creates a new isolated environment instance each time it is called.


### PR DESCRIPTION
Acceptance test failures generally require access to the machine and
that failed in order to inspect directly. Provide the ability for
consumers to be able to enable or disable clean up after test failures
depending on their needs around debugging.
