### PR TITLE
subprocess: Fix the argument delegation with Ruby 3.0

### DIFF
--- a/lib/vagrant-spec/subprocess.rb
+++ b/lib/vagrant-spec/subprocess.rb
@@ -24,8 +24,8 @@ module Vagrant
       READ_CHUNK_SIZE = 4096
 
       # Convenience method for executing a method.
-      def self.execute(command, *args, &block)
-        new(command, *args).execute(&block)
+      def self.execute(command, *args, **options, &block)
+        new(command, *args, **options).execute(&block)
       end
 
       def initialize(command, *args, **options)


### PR DESCRIPTION
This PR fixes the following error which currently happens on Ruby 3.0:

```
provider/parallels/disk/basic
  it should behave like provider/disk/basic
    configures storage mediums
      Execute: vagrant box add box /Users/legal/Workspace/vagrant-parallels/boxes/centos-7.8.box
      Execute: vagrant destroy --force
      configures storage mediums (FAILED - 1)

Failures:

  1) provider/parallels/disk/basic it should behave like provider/disk/basic configures storage mediums
     Got 0 failures and 2 other errors:
     Shared Example Group: "provider/disk/basic" called from

     1.1) Failure/Error: raise ArgumentError, message

          ArgumentError:
            A list of notify subscriptions must be given if a block is given
          # /Users/legal/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/bundler/gems/vagrant-spec-708be5c53ea1/lib/vagrant-spec/subprocess.rb:52:in `execute'
          # /Users/legal/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/bundler/gems/vagrant-spec-708be5c53ea1/lib/vagrant-spec/subprocess.rb:28:in `execute'
          # /Users/legal/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/bundler/gems/vagrant-spec-708be5c53ea1/lib/vagrant-spec/acceptance/isolated_environment.rb:62:in `execute'
          # /Users/legal/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/bundler/gems/vagrant-spec-708be5c53ea1/lib/vagrant-spec/acceptance/rspec/context.rb:54:in `execute'
          # /Users/legal/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/bundler/gems/vagrant-spec-708be5c53ea1/lib/vagrant-spec/acceptance/rspec/context.rb:61:in `assert_execute'
          # /Users/legal/.rbenv/versions/3.0.4/lib/ruby/gems/3.0.0/bundler/gems/vagrant-spec-708be5c53ea1/acceptance/disk/basic_spec.rb:14:in `block (2 levels) in <top (required)>'
```

The route cause is the way how Ruby 3.0 handle the argument delegation. 
See more details in the section "Handling argument delegation" here: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
